### PR TITLE
Corregge la query di ricerca per il form di modifica degli eventi in evidenza

### DIFF
--- a/classes/connectors/LockEdit/Page/LiveLockEditClassConnector.php
+++ b/classes/connectors/LockEdit/Page/LiveLockEditClassConnector.php
@@ -64,7 +64,7 @@ class LiveLockEditClassConnector extends PageLockEditClassConnector
         }else{
             $options['fields']['title_evidence']['helper'] = '';
             $options['fields']['section_evidence']['browse']['subtree'] = $this->fetchMainNodeIDByObjectRemoteID('all-events');
-            $options['fields']['section_evidence']['browse']['classes'] = ['event', 'event_link'];
+            $options['fields']['section_evidence']['browse']['classes'] = ['event'];
         }
 
         return $options;


### PR DESCRIPTION
Rimuove il parametro event_link (che comunque se serve viene aggiunto in fase di parsing della query)