### PR TITLE
feat: pre-popola anno del bando con l'anno corrente alla creazione

### DIFF
--- a/design/bootstrapitalia2/templates/content/edit_attribute.tpl
+++ b/design/bootstrapitalia2/templates/content/edit_attribute.tpl
@@ -169,3 +169,27 @@
         {/foreach}
     </div>
 </div>
+{def $prepopulate_year_on_create = ezini('EditDefaults', 'PrePopulateCurrentYearOnCreate', 'openpa.ini')}
+{if $prepopulate_year_on_create|count()|gt(0)}
+<script>
+var _yearOnCreateFields = "{$prepopulate_year_on_create|implode('|')|wash()}";
+var _yearOnCreateClass = "{$class.identifier|wash()}";
+{literal}
+(function() {
+    _yearOnCreateFields.split('|').filter(Boolean)
+        .filter(function(e) { return e.split('/')[0] === _yearOnCreateClass; })
+        .map(function(e) { return e.split('/')[1]; })
+        .forEach(function(id) {
+            var container = document.querySelector('[data-attribute_identifier="' + id + '"]');
+            if (container) {
+                var input = container.querySelector('input');
+                if (input && (input.value === '0' || input.value === '')) {
+                    input.value = new Date().getFullYear();
+                }
+            }
+        });
+})();
+{/literal}
+</script>
+{/if}
+{undef $prepopulate_year_on_create}

--- a/design/bootstrapitalia2110/templates/content/edit_attribute.tpl
+++ b/design/bootstrapitalia2110/templates/content/edit_attribute.tpl
@@ -170,3 +170,27 @@
         {/foreach}
     </div>
 </div>
+{def $prepopulate_year_on_create = ezini('EditDefaults', 'PrePopulateCurrentYearOnCreate', 'openpa.ini')}
+{if $prepopulate_year_on_create|count()|gt(0)}
+<script>
+var _yearOnCreateFields = "{$prepopulate_year_on_create|implode('|')|wash()}";
+var _yearOnCreateClass = "{$class.identifier|wash()}";
+{literal}
+(function() {
+    _yearOnCreateFields.split('|').filter(Boolean)
+        .filter(function(e) { return e.split('/')[0] === _yearOnCreateClass; })
+        .map(function(e) { return e.split('/')[1]; })
+        .forEach(function(id) {
+            var container = document.querySelector('[data-attribute_identifier="' + id + '"]');
+            if (container) {
+                var input = container.querySelector('input');
+                if (input && (input.value === '0' || input.value === '')) {
+                    input.value = new Date().getFullYear();
+                }
+            }
+        });
+})();
+{/literal}
+</script>
+{/if}
+{undef $prepopulate_year_on_create}

--- a/settings/openpa.ini.append.php
+++ b/settings/openpa.ini.append.php
@@ -376,4 +376,9 @@ Headers[]
 [AlboPretorioSettings]
 AllowApiSequentialId=disabled
 
+# Attributi ezinteger che non supportano default dinamici nel backend eZ.
+# Il valore viene pre-popolato con l'anno corrente via JS al momento della creazione.
+[EditDefaults]
+PrePopulateCurrentYearOnCreate[]=bando/anno
+
 */ ?>


### PR DESCRIPTION
Aggiunge [EditDefaults] PrePopulateCurrentYearOnCreate in openpa.ini. La configurazione è generica (classe/attributo) e documentata: ezinteger non supporta default dinamici nel backend eZ, il valore viene impostato via JS solo se il campo vale 0 (mai valorizzato).