### PR TITLE
feat: mostra tutti gli argomenti degli event_link OpenAgenda

### DIFF
--- a/classes/indexplugins/index_event_link.php
+++ b/classes/indexplugins/index_event_link.php
@@ -13,19 +13,28 @@ class ezfIndexEventLink implements ezfIndexPlugin
         $openpa = OpenPAObjectHandler::instanceFromObject($contentObject);
         if ($openpa->hasAttribute('event_link')) {
             $link = $openpa->attribute('event_link');
-            $topic = $link->attribute('topic');
-            if ($topic instanceof eZContentObject) {
+            $topics = $link->attribute('topics');
+            if (!empty($topics)) {
+                $ids = $contentclassIds = $remoteIds = $classIdentifiers = $mainNodeIds = $names = [];
+                foreach ($topics as $topic) {
+                    $ids[] = $topic->attribute('id');
+                    $contentclassIds[] = $topic->attribute('contentclass_id');
+                    $remoteIds[] = $topic->attribute('remote_id');
+                    $classIdentifiers[] = $topic->attribute('class_identifier');
+                    $mainNodeIds[] = $topic->attribute('main_node_id');
+                    $names[] = $topic->attribute('name');
+                }
                 $virtualTopic = [
-                    'submeta_topics___id____si' => $topic->attribute('id'),
-                    'submeta_topics___contentclass_id____si' => $topic->attribute('contentclass_id'),
-                    'submeta_topics___remote_id____ms' => $topic->attribute('remote_id'),
-                    'submeta_topics___class_identifier____ms' => $topic->attribute('class_identifier'),
-                    'submeta_topics___main_node_id____si' => $topic->attribute('main_node_id'),
-                    'submeta_topics___name____t' => $topic->attribute('name'),
-                    'subattr_topics___name____s' => $topic->attribute('name'),
-                    'subattr_topics___name____t' => $topic->attribute('name'),
-                    'attr_topics_t' => $topic->attribute('name'),
-                    'attr_topics_s' => $topic->attribute('name'),
+                    'submeta_topics___id____si' => $ids,
+                    'submeta_topics___contentclass_id____si' => $contentclassIds,
+                    'submeta_topics___remote_id____ms' => $remoteIds,
+                    'submeta_topics___class_identifier____ms' => $classIdentifiers,
+                    'submeta_topics___main_node_id____si' => $mainNodeIds,
+                    'submeta_topics___name____t' => implode(' ', $names),
+                    'subattr_topics___name____s' => $names,
+                    'subattr_topics___name____t' => implode(' ', $names),
+                    'attr_topics_t' => implode(' ', $names),
+                    'attr_topics_s' => $names,
                 ];
             }
             $type = $link->attribute('has_public_event_typology');

--- a/classes/services/event_link.php
+++ b/classes/services/event_link.php
@@ -8,6 +8,8 @@ class ObjectHandlerServiceEventLink extends ObjectHandlerServiceBase
 
     private $topic;
 
+    private $topics;
+
     private $place;
 
     private $geo;
@@ -19,7 +21,9 @@ class ObjectHandlerServiceEventLink extends ObjectHandlerServiceBase
         $this->fnData['has_public_event_typology'] = 'getPublicEventTypology';
         $this->fnData['has_public_event_typology_name'] = 'getPublicEventTypologyName';
         $this->fnData['topic'] = 'getTopic';
+        $this->fnData['topics'] = 'getTopics';
         $this->fnData['topic_name'] = 'getTopicName';
+        $this->fnData['topic_names'] = 'getTopicNames';
         $this->fnData['image'] = 'getImage';
         $this->fnData['takes_place_in'] = 'getTakesPlaceIn';
         $this->fnData['geo'] = 'getGeo';
@@ -158,21 +162,45 @@ class ObjectHandlerServiceEventLink extends ObjectHandlerServiceBase
     protected function getTopicName()
     {
         $data = $this->getMatrixAsHash('virtual_topic');
-        return $data['name'] ?? null;
+        return $data[0]['name'] ?? null;
+    }
+
+    protected function getTopicNames()
+    {
+        $names = [];
+        foreach ($this->getMatrixAsHash('virtual_topic') as $item) {
+            if (!empty($item['name'])) {
+                $names[] = $item['name'];
+            }
+        }
+        return $names;
+    }
+
+    protected function getTopics()
+    {
+        if ($this->topics === null) {
+            $this->topics = [];
+            $data = $this->getMatrixAsHash('virtual_topic');
+            foreach ($data as $item) {
+                if (!empty($item['id'])) {
+                    $object = eZContentObject::fetchByRemoteID($item['id']);
+                    if ($object instanceof eZContentObject) {
+                        $this->topics[] = $object;
+                    }
+                }
+            }
+        }
+
+        return $this->topics;
     }
 
     protected function getTopic()
     {
         if ($this->topic === null) {
             $this->topic = false;
-            $data = $this->getMatrixAsHash('virtual_topic');
-            foreach ($data as $item) {
-                if (!empty($item['id'])) {
-                    $this->topic = eZContentObject::fetchByRemoteID($item['id']);
-                    if ($this->topic instanceof eZContentObject) {
-                        break;
-                    }
-                }
+            $topics = $this->getTopics();
+            if (!empty($topics)) {
+                $this->topic = $topics[0];
             }
         }
 

--- a/design/bootstrapitalia2/templates/openpa/full/event_link.tpl
+++ b/design/bootstrapitalia2/templates/openpa/full/event_link.tpl
@@ -35,28 +35,32 @@
         <div class="col-lg-3 offset-lg-1">
             {include uri='design:openpa/full/parts/actions.tpl'}
             <div class="mt-4 mb-4">
-                {if $openpa.event_link.topic}
+                {if $openpa.event_link.topics}
                     <div class="row">
                         <span class="mb-2 small">{'Topics'|i18n('bootstrapitalia')}</span>
                     </div>
                     <ul class="d-flex flex-wrap gap-1 mb-2">
+                        {foreach $openpa.event_link.topics as $topic}
                         <li>
                             <a class="chip chip-simple chip-primary"
-                               href="{$openpa.event_link.topic.main_node.url_alias|ezurl(no)}">
-                                <span class="chip-label">{$openpa.event_link.topic.name|wash()}</span>
+                               href="{$topic.main_node.url_alias|ezurl(no)}">
+                                <span class="chip-label">{$topic.name|wash()}</span>
                             </a>
                         </li>
+                        {/foreach}
                     </ul>
-                {elseif $openpa.event_link.topic_name}
+                {elseif $openpa.event_link.topic_names}
                     <div class="row">
                         <span class="mb-2 small">{'Topics'|i18n('bootstrapitalia')}</span>
                     </div>
                     <ul class="d-flex flex-wrap gap-1 mb-2">
+                        {foreach $openpa.event_link.topic_names as $topic_name}
                         <li>
                             <span class="chip chip-simple chip-primary">
-                                <span class="chip-label">{$openpa.event_link.topic_name|wash()}</span>
+                                <span class="chip-label">{$topic_name|wash()}</span>
                             </span>
                         </li>
+                        {/foreach}
                     </ul>
                 {/if}
                 {if $openpa.event_link.has_public_event_typology}

--- a/design/bootstrapitalia2110/templates/openpa/full/event_link.tpl
+++ b/design/bootstrapitalia2110/templates/openpa/full/event_link.tpl
@@ -35,28 +35,32 @@
         <div class="col-lg-3 offset-lg-1">
             {include uri='design:openpa/full/parts/actions.tpl'}
             <div class="mt-4 mb-4">
-                {if $openpa.event_link.topic}
+                {if $openpa.event_link.topics}
                     <div class="row">
                         <span class="mb-2 small">{'Topics'|i18n('bootstrapitalia')}</span>
                     </div>
                     <ul class="d-flex flex-wrap gap-1 mb-2">
+                        {foreach $openpa.event_link.topics as $topic}
                         <li>
                             <a class="chip chip-simple chip-primary"
-                               href="{$openpa.event_link.topic.main_node.url_alias|ezurl(no)}">
-                                <span class="chip-label">{$openpa.event_link.topic.name|wash()}</span>
+                               href="{$topic.main_node.url_alias|ezurl(no)}">
+                                <span class="chip-label">{$topic.name|wash()}</span>
                             </a>
                         </li>
+                        {/foreach}
                     </ul>
-                {elseif $openpa.event_link.topic_name}
+                {elseif $openpa.event_link.topic_names}
                     <div class="row">
                         <span class="mb-2 small">{'Topics'|i18n('bootstrapitalia')}</span>
                     </div>
                     <ul class="d-flex flex-wrap gap-1 mb-2">
+                        {foreach $openpa.event_link.topic_names as $topic_name}
                         <li>
                             <span class="chip chip-simple chip-primary">
-                                <span class="chip-label">{$openpa.event_link.topic_name|wash()}</span>
+                                <span class="chip-label">{$topic_name|wash()}</span>
                             </span>
                         </li>
+                        {/foreach}
                     </ul>
                 {/if}
                 {if $openpa.event_link.has_public_event_typology}


### PR DESCRIPTION
Aggiunge getTopics() che restituisce tutti i topic locali trovati in virtual_topic (invece di fermarsi al primo). getTopic() diventa un alias che ritorna il primo elemento. Aggiunge getTopicNames() per il fallback testuale quando nessun topic locale è presente.

I template full (design 2 e 2110) ora iterano su topics/topic_names con foreach invece di mostrare un solo chip.

Il plugin Solr indicizza tutti i topic nell'array multi-valore.