### PR TITLE
Mostra data evento in formato compatto nelle card teaser

### DIFF
--- a/design/bootstrapitalia/templates/openpa/card_teaser/parts/attributes.tpl
+++ b/design/bootstrapitalia/templates/openpa/card_teaser/parts/attributes.tpl
@@ -8,13 +8,13 @@
             {if $node|attribute($identifier).data_type_string|eq('ezobjectrelationlist')}
                 <div id="{concat($node|attribute($identifier).contentclass_attribute_identifier,'-',$node|attribute($identifier).id)}">
                 {foreach $node|attribute($identifier).content.relation_list as $item}
-                    {def $item_object = fetch(content, object, hash(object_id, $item.contentobject_id))}                    
-                    {content_view_gui content_object=$item_object 
-                                      view=embed-inline 
-                                      count=count($node|attribute($identifier).content.relation_list) 
+                    {def $item_object = fetch(content, object, hash(object_id, $item.contentobject_id))}
+                    {content_view_gui content_object=$item_object
+                                      view=embed-inline
+                                      count=count($node|attribute($identifier).content.relation_list)
                                       container_parent_id=concat($node|attribute($identifier).contentclass_attribute_identifier,'-',$node|attribute($identifier).id)
                                       container_has_image=cond(and($attributes.show|contains('image'), $node|has_attribute('image')), true(), false())
-                                      show_icon=false() 
+                                      show_icon=false()
                                       show_link=cond($attributes.show_link|contains($identifier), true(), false())}
                     {undef $item_object}
                 {/foreach}
@@ -24,7 +24,8 @@
                                     image_class=small
                                     show_link=false()
                                     only_address=true()
-                                    avoid_oembed=true()}
+                                    avoid_oembed=true()
+                                    compact=true()}
             {else}
             {/if}
             </p>

--- a/design/bootstrapitalia2/templates/content/datatype/view/ocevent.tpl
+++ b/design/bootstrapitalia2/templates/content/datatype/view/ocevent.tpl
@@ -1,5 +1,22 @@
 {set-block scope=root variable=cache_ttl}86400{/set-block}
 
+{if $compact}
+    {def $oc_events = $attribute.content.events}
+    {if count($oc_events)|gt(0)}
+        <p class="mb-2 fw-semibold">
+          {if count($oc_events)|gt(10)}
+              {"Event daytime text"|i18n('bootstrapitalia')} {recurrences_strtotime($oc_events[0].start)|datetime('custom','%j %F %Y')|downcase}, {$attribute.content.text|wash()}
+          {elseif count($oc_events)|gt(1)}
+              {'From'|i18n('bootstrapitalia/documents')} {recurrences_strtotime($oc_events[0].start)|datetime('custom','%j %F %Y')|downcase}
+          {elseif recurrences_strtotime($oc_events[0].start)|datetime('custom','%j%m%Y')|ne(recurrences_strtotime($oc_events[0].end)|datetime('custom','%j%m%Y'))}
+              {'From'|i18n('bootstrapitalia/documents')} {recurrences_strtotime($oc_events[0].start)|datetime('custom','%j %F %Y')|downcase} {'to'|i18n('bootstrapitalia/documents')} {recurrences_strtotime($oc_events[0].end)|datetime('custom','%j %F %Y')|downcase}
+          {else}
+              {recurrences_strtotime($oc_events[0].start)|datetime('custom','%j %F %Y')|downcase}
+          {/if}
+        </p>
+    {/if}
+    {undef $oc_events}
+{else}
 
 {def $events = $attribute.content.events}
 
@@ -71,3 +88,4 @@
     {/foreach}
     {undef $events}
 </div>
+{/if}


### PR DESCRIPTION
Nelle card teaser (ricerca, blocchi) il datatype ocevent mostra ora una riga di data semplificata invece del calendario completo:
- evento ricorrente (>10): testo ricorrenza senza lista appuntamenti
- evento con più occorrenze: "Dal [prima data]"
- evento multi-giorno: "Dal [inizio] al [fine]"
- evento singolo: "[data]"